### PR TITLE
Fix New-PfAsset

### DIFF
--- a/MpsPowershell/PlayFabMultiplayerApi.psd1
+++ b/MpsPowershell/PlayFabMultiplayerApi.psd1
@@ -1,7 +1,7 @@
 @{
   GUID = '31171fb3-b53e-45b6-bd41-96e4ddf9afe3'
   RootModule = './PlayFabMultiplayerApi.psm1'
-  ModuleVersion = '1.0.0'
+  ModuleVersion = '1.1.0'
   CompatiblePSEditions = 'Core', 'Desktop'
   Author = 'Microsoft Corporation'
   CompanyName = 'Microsoft Corporation'

--- a/MpsPowershell/custom/NewPfAsset.ps1
+++ b/MpsPowershell/custom/NewPfAsset.ps1
@@ -1,5 +1,5 @@
 function New-PfAsset {
-    [OutputType('PlayFab.Multiplayer.Models.IComponentsHvu8TvResponsesGetassetuploadurlresponseContentApplicationJsonSchema', 'PlayFab.Multiplayer.Models.IApiErrorWrapper', 'PSObject')]
+    [OutputType('PlayFab.Multiplayer.Models.IComponentsHvu8TvResponsesGetassetuploadurlresponseContentApplicationJsonSchema', 'PlayFab.Multiplayer.Models.IApiErrorWrapper', 'System.Net.Http.HttpResponseMessage')]
     [CmdletBinding(PositionalBinding=$false)]
     [PlayFab.Multiplayer.Description('Uploads an asset.')]
     param(
@@ -9,7 +9,11 @@ function New-PfAsset {
 
         [Parameter(Mandatory, HelpMessage='The name of the asset to upload.')]
         [System.String]
-        ${AssetName}
+        ${AssetName},
+
+        [Parameter(HelpMessage='The size of the buffer used for uploading (in bytes).')]
+        [int]
+        ${BufferSize} = 4 * 1024 * 1024
 
         # Common parameters omitted
     )
@@ -21,14 +25,55 @@ function New-PfAsset {
             return $getAssetUploadUrlResponse
         }
 
-        $response = Invoke-RestMethod `
-            -method PUT `
-            -URI $getAssetUploadUrlResponse.Data.AssetUploadUrl `
-            -headers @{ "x-ms-blob-type" = "BlockBlob" } `
-            -InFile ${FilePath}
+        $httpClient = [System.Net.Http.HttpClient]::new();
 
-        Write-Host "Success"
+        $fileStream = $null;
+        try {
+            $fileStream = [System.IO.File]::OpenRead(${FilePath});
 
-        return $response
+            $buffer = [System.Byte[]]::new(${BufferSize});
+
+            $blockNum = 0;
+            $base64BlockIds = [System.Collections.ArrayList]::new();
+            
+            $numBytesRead = $fileStream.Read($buffer, 0, ${BufferSize});
+            while ($numBytesRead -gt 0) { 
+                $blockId = $blockNum.ToString().PadLeft(15, "0");
+                $base64BlockId = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($blockId));
+                $null = $base64BlockIds.Add($base64BlockId);
+
+                $uri = "$($getAssetUploadUrlResponse.Data.AssetUploadUrl)&comp=block&blockId=$([System.Net.WebUtility]::UrlEncode(${base64BlockId}))";
+                $body = [System.Net.Http.ByteArrayContent]::new($buffer, 0, $numBytesRead);
+                $putBlockResponse = $httpClient.PutAsync($uri, $body).GetAwaiter().GetResult();
+
+                $null = $putBlockResponse.EnsureSuccessStatusCode();
+
+                $numBytesRead = $fileStream.Read($buffer, 0, $bufferSize);
+                $blockNum += 1;
+            }
+
+            $putBlockListBody = [System.Text.StringBuilder]::new();
+            $null = $putBlockListBody.AppendLine('<?xml version="1.0" encoding="utf-8"?>');
+            $null = $putBlockListBody.AppendLine("<BlockList>");
+
+            foreach ($base64BlockId in $base64BlockIds) {
+                $null = $putBlockListBody.AppendLine("<Uncommitted>${base64BlockId}</Uncommitted>");
+            }
+
+            $null = $putBlockListBody.AppendLine("</BlockList>");
+
+            $uri = "$($getAssetUploadUrlResponse.Data.AssetUploadUrl)&comp=blocklist";
+            $body = [System.Net.Http.StringContent]::new($putBlockListBody.ToString());
+            $putBlockListResponse = $httpClient.PutAsync($uri, $body).GetAwaiter().GetResult();
+
+            $null = $putBlockListResponse.EnsureSuccessStatusCode();
+
+            return $putBlockListResponse;
+        }
+        finally {
+            if ($fileStream) { 
+                $fileStream.Dispose();
+            }
+        }
     }
 }

--- a/MpsPowershell/docs/New-PfAsset.md
+++ b/MpsPowershell/docs/New-PfAsset.md
@@ -13,7 +13,7 @@ Uploads an asset.
 ## SYNTAX
 
 ```
-New-PfAsset -AssetName <String> -FilePath <String> [<CommonParameters>]
+New-PfAsset -AssetName <String> -FilePath <String> [-BufferSize <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -24,10 +24,26 @@ Uploads an asset.
 ### Example 1: Upload an asset
 ```powershell
 PS C:\> New-PfAsset -FilePath C:\example.zip -AssetName example.zip
-Success
+
+Version             : 1.1
+Content             : System.Net.Http.StreamContent
+StatusCode          : Created
+ReasonPhrase        : Created
+Headers             : {[x-ms-request-id, System.String[]], [x-ms-version, System.String[]], [x-ms-request-server-encrypted,
+                      System.String[]], [Date, System.String[]]...}
+RequestMessage      : Method: PUT, RequestUri: 'https://example.blob.core.windows.net/gameassets/example.zip?sv=2015-
+                      04-05&ss=b&srt=sco&sp=rw&st=2021-05-07T16:17:02.6110864Z&se=2021-05-07T22:17:02.6110856Z&spr=https&sig=YOf
+                      bOYfU5Po5Bu/Wpxx3VVPJPYsFAHRgflH4UCR9J7U=&api-version=2018-03-28&comp=blocklist', Version: 1.1, Content:
+                      System.Net.Http.StringContent, Headers:
+                      {
+                        Content-Type: text/plain; charset=utf-8
+                        Content-Length: 116
+                      }
+IsSuccessStatusCode : True
 ```
 
-This command first calls Get-AssetUploadUrl and then uses the Azure REST API to upload given file to the obtained Azure storage URL.
+This command first calls Get-AssetUploadUrl and then uses the Azure REST API to upload given file to the obtained Azure storage URL as a series of blocks.
+Returns the HttpResponseMessage from the final Commit Atom BlockList call to Azure.
 
 ## PARAMETERS
 
@@ -40,6 +56,21 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BufferSize
+The size of the buffer used for uploading (in bytes).
+
+```yaml
+Type: System.Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -72,7 +103,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### PlayFab.Multiplayer.Models.IComponentsHvu8TvResponsesGetassetuploadurlresponseContentApplicationJsonSchema
 
-### System.Management.Automation.PSObject
+### System.Net.Http.HttpResponseMessage
 
 ## NOTES
 

--- a/MpsPowershell/examples/New-PfAsset.md
+++ b/MpsPowershell/examples/New-PfAsset.md
@@ -1,8 +1,23 @@
 ### Example 1: Upload an asset
 ```powershell
 PS C:\> New-PfAsset -FilePath C:\example.zip -AssetName example.zip
-Success
+
+Version             : 1.1
+Content             : System.Net.Http.StreamContent
+StatusCode          : Created
+ReasonPhrase        : Created
+Headers             : {[x-ms-request-id, System.String[]], [x-ms-version, System.String[]], [x-ms-request-server-encrypted,
+                      System.String[]], [Date, System.String[]]...}
+RequestMessage      : Method: PUT, RequestUri: 'https://example.blob.core.windows.net/gameassets/example.zip?sv=2015-
+                      04-05&ss=b&srt=sco&sp=rw&st=2021-05-07T16:17:02.6110864Z&se=2021-05-07T22:17:02.6110856Z&spr=https&sig=YOf
+                      bOYfU5Po5Bu/Wpxx3VVPJPYsFAHRgflH4UCR9J7U=&api-version=2018-03-28&comp=blocklist', Version: 1.1, Content:
+                      System.Net.Http.StringContent, Headers:
+                      {
+                        Content-Type: text/plain; charset=utf-8
+                        Content-Length: 116
+                      }
+IsSuccessStatusCode : True
 ```
 
-This command first calls Get-AssetUploadUrl and then uses the Azure REST API to upload given file to the obtained Azure storage URL.
+This command first calls Get-AssetUploadUrl and then uses the Azure REST API to upload given file to the obtained Azure storage URL as a series of blocks. Returns the HttpResponseMessage from the final Commit Atom BlockList call to Azure.
 


### PR DESCRIPTION
Previously New-PfAsset uploaded the asset to Azure in a single Put Blob request. Turns out there's a limit on the size of a Put Blob upload, so to fix that I had to add logic to upload the asset using multiple Put **Block** requests.
The default block size is set to 4MiB, so New-PfAsset will now upload a 512MiB asset as 128 blocks instead of trying to make a single 512MiB upload request.

I'm using the REST api instead of the Azure Powershell or C# SDKs because the Powershell SDK doesn't accept the SAS urls from ControlPlane and the C# SDK runs into DLL conflicts when running on Windows Powershell vs Powershell Core.