### PR TITLE
dispose of ByteArrayContent in New-PFAsset

### DIFF
--- a/MpsPowershell/PlayFabMultiplayerApi.psd1
+++ b/MpsPowershell/PlayFabMultiplayerApi.psd1
@@ -1,7 +1,7 @@
 @{
   GUID = '6348811f-9e9e-4e9c-af4b-d59304561887'
   RootModule = './PlayFabMultiplayerApi.psm1'
-  ModuleVersion = '2.1.0'
+  ModuleVersion = '2.1.1'
   CompatiblePSEditions = 'Core', 'Desktop'
   Author = 'Microsoft Corporation'
   CompanyName = 'Microsoft Corporation'

--- a/MpsPowershell/custom/NewPfAsset.ps1
+++ b/MpsPowershell/custom/NewPfAsset.ps1
@@ -38,14 +38,15 @@ function New-PfAsset {
             
             $numBytesRead = $fileStream.Read($buffer, 0, ${BufferSize});
             while ($numBytesRead -gt 0) {
-                $body = [System.Net.Http.ByteArrayContent]::new($buffer, 0, $numBytesRead);
-
                 $numFailures = 0;
                 $maxRetries = 5;
                 $lastError = $null;
+                $body = $null;
 
                 while ($numFailures -lt $maxRetries) {
                     try {
+                        $body = [System.Net.Http.ByteArrayContent]::new($buffer, 0, $numBytesRead);
+
                         # include numFailures in the blockId so that we never attempt to reupload an existing blockId
                         $blockId = "${blockNum}_${numFailures}".PadLeft(15, "0");
                         $base64BlockId = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($blockId));
@@ -74,6 +75,10 @@ function New-PfAsset {
                             [Console]::ForegroundColor = [ConsoleColor]::DarkGray;
                             [Console]::Error.WriteLine("$lastError");
                             [Console]::ResetColor();
+                        }
+                    } finally {
+                        if ($null -ne $body) {
+                            $body.Dispose();
                         }
                     }
                 }


### PR DESCRIPTION
Since we were reusing the $body with each retry, we'd get a `Cannot access a disposed object` error on the 2nd attempt. Now we are disposing and recreating $body with each attempt